### PR TITLE
Refactor expansion panel conditions for aliens

### DIFF
--- a/pre-registration-ui/src/app/feature/demographic-alien/demographic-alien/demographic-alien.component.html
+++ b/pre-registration-ui/src/app/feature/demographic-alien/demographic-alien/demographic-alien.component.html
@@ -288,7 +288,7 @@
 
           <mat-accordion class="example-headers-align">
 
-            <mat-expansion-panel *ngIf="isNewAlien() || isRenewalAlien() || isReplacementAlien()"
+            <mat-expansion-panel *ngIf="isNewAlien() || isRenewalAlien()"
               [expanded]="expStep === 1" (opened)="setStep(1)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -550,7 +550,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien() || isReplacementAlien()) && (isDependentPass())" [expanded]="expStep === 2" (opened)="setStep(2)" hideToggle>
+            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien()) && (isDependentPass())" [expanded]="expStep === 2" (opened)="setStep(2)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
                   <b>Linked Dependent to Principal:</b>
@@ -2236,7 +2236,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="isNewAlien() || isRenewalAlien() || isReplacementAlien()"
+            <mat-expansion-panel *ngIf="isNewAlien() || isRenewalAlien()"
               [expanded]="expStep === 5" (opened)="setStep(5)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -2506,7 +2506,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="!isCopService() && !isGetFirstId() && !isReplacement()"
+            <mat-expansion-panel *ngIf="!isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien()"
               [expanded]="expStep === 6" (opened)="setStep(6)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -2781,7 +2781,7 @@
             </mat-expansion-panel>
 
             <mat-expansion-panel
-              *ngIf="!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement()"
+              *ngIf="!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien()"
               [expanded]="expStep === 7" (opened)="setStep(7)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -3044,7 +3044,7 @@
             </mat-expansion-panel>
 
             <mat-expansion-panel
-              *ngIf="!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement()"
+              *ngIf="!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien()"
               [expanded]="expStep === 8" (opened)="setStep(8)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title *ngIf="isByBirth()">
@@ -3321,7 +3321,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien() || isReplacementAlien()) && isOtherPass()"
+            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien()) && isOtherPass()"
               [expanded]="expStep === 9" (opened)="setStep(9)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -3583,7 +3583,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien() || isReplacementAlien()) && isStudentPass()"
+            <mat-expansion-panel *ngIf="(isNewAlien() || isRenewalAlien()) && isStudentPass()"
               [expanded]="expStep === 10" (opened)="setStep(10)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -3845,7 +3845,7 @@
               </mat-action-row>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement())"
+            <mat-expansion-panel *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien())"
               [expanded]="expStep === 11" (opened)="setStep(11)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -4108,7 +4108,7 @@
             </mat-expansion-panel>
 
             <mat-expansion-panel
-              *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement())"
+              *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien())"
               [expanded]="expStep === 12" (opened)="setStep(12)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -4392,11 +4392,11 @@
             </mat-expansion-panel>
 
             <mat-expansion-panel
-              *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement())"
+              *ngIf="(!isRenewalService() && !isCopService() && !isGetFirstId() && !isReplacement() && !isReplacementAlien())"
               [expanded]="expStep === 13" (opened)="setStep(13)" hideToggle>
               <mat-expansion-panel-header>
                 <mat-panel-title>
-                  <b>Particular of Applicant’s Dependant :</b>
+                  <b>Particular of Applicant’s Dependants :</b>
                 </mat-panel-title>
                 <mat-panel-description>
                   Maximum of 6 dependants can be added


### PR DESCRIPTION
Updated conditions for displaying expansion panels related to alien demographics, removing references to 'isReplacementAlien' in multiple instances.